### PR TITLE
Revised roving multispect to use Space than Enter.

### DIFF
--- a/roving-tab-index/index.html
+++ b/roving-tab-index/index.html
@@ -14,9 +14,7 @@
     <h1>Roving Tabindex for Listboxes</h1>
     <p>What is roving tabindex? <a href="https://www.youtube.com/watch?v=uCIC2LNt0bk"
         https://www.youtube.com/watch?v=uCIC2LNt0bk>Rob Dodson has a great A11yCast</a> that&rsquo;s just fourteen
-      minutes! JavaScript code for the roving tabindex was <a
-        href="https://a11y-solutions.stevenwoodson.com/solutions/focus/roving-focus/">provided by Steve Woodson</a> and
-      modded by me.</p>
+      minutes!</p>
     <h2 id="heading-1">Select a single option</h2>
     <ul aria-labelledby="heading-1" id="list-group-1" class="roving-list" role="listbox">
       <li tabindex="0" aria-checked="true" aria-selected="true" class="roving-list-item roving-list-item--selected"
@@ -57,6 +55,9 @@
     </ul>
     <hr />
     <h2>Written using old skool prototypal inheritance</h2>
+    <p>JavaScript code for the roving tabindex was <a
+        href="https://a11y-solutions.stevenwoodson.com/solutions/focus/roving-focus/">provided by Steve Woodson</a> and
+      modded by me.</p>
     <p><a href="https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Objects/Object-oriented_JS">Learn more about
         object-oriented JavaScript</a> on the Mozilla Developer Network (MDN).</a> Did you notice the keyboard focus
       jumped from the first two links to one of the list items to the last link when you pressed the <code>TAB</code>

--- a/roving-tab-index/js/constants/constants.js
+++ b/roving-tab-index/js/constants/constants.js
@@ -1,9 +1,10 @@
 const keys = {
-  LEFT: 'ArrowLeft',
-  UP: 'ArrowUp',
-  RIGHT: 'ArrowRight',
-  DOWN: 'ArrowDown',
-  ENTER: 'Enter',
+  LEFT: "ArrowLeft",
+  UP: "ArrowUp",
+  RIGHT: "ArrowRight",
+  DOWN: "ArrowDown",
+  ENTER: "Enter",
+  SPACE: " ",
 };
 
 export { keys };

--- a/roving-tab-index/js/helpers/slice.js
+++ b/roving-tab-index/js/helpers/slice.js
@@ -1,9 +1,0 @@
-/**
- * Convert an HTML collection into a proper array of elements
- * 
- * @param {HTMLCollection} nodes list item nodes
- * @returns {Array} array of LI elmenets
- */
-export default function slice(nodes) {
-  return Array.prototype.slice.call(nodes);
-}

--- a/roving-tab-index/js/modules/RovingMultiselect.js
+++ b/roving-tab-index/js/modules/RovingMultiselect.js
@@ -15,7 +15,6 @@ function RovingMultiselect(id, targetClass) {
 }
 
 RovingMultiselect.prototype.handleClick = function (e) {
-  console.log("Click event registered");
   const children = e.target.parentNode.children;
 
   for (let i = 0; i < children.length; i++) {

--- a/roving-tab-index/js/modules/RovingMultiselect.js
+++ b/roving-tab-index/js/modules/RovingMultiselect.js
@@ -1,21 +1,21 @@
-import slice from '../helpers/slice.js';
-import uniqueId from '../helpers/uniqueId.js';
+import uniqueId from "../helpers/uniqueId.js";
 import { keys } from "../constants/constants.js";
 
 function RovingMultiselect(id, targetClass) {
   this.el = document.querySelector(id);
-  this.listItems = slice(this.el.querySelectorAll(targetClass));
+  this.listItems = [...this.el.querySelectorAll(targetClass)];
   this.selected = 0;
   this.focusedItem = this.listItems[this.selected];
   this.createUniqueId(this.listItems);
 
-  this.el.addEventListener('focusin', this.handleFocusIn.bind(this));
-  this.el.addEventListener('focusout', this.handleFocusOut.bind(this));
-  this.el.addEventListener('keydown', this.handleKeyDown.bind(this));
-  this.el.addEventListener('click', this.handleClick.bind(this));
-};
+  this.el.addEventListener("focusin", this.handleFocusIn.bind(this));
+  this.el.addEventListener("focusout", this.handleFocusOut.bind(this));
+  this.el.addEventListener("keydown", this.handleKeyDown.bind(this));
+  this.el.addEventListener("click", this.handleClick.bind(this));
+}
 
-RovingMultiselect.prototype.handleClick = function(e) {
+RovingMultiselect.prototype.handleClick = function (e) {
+  console.log("Click event registered");
   const children = e.target.parentNode.children;
 
   for (let i = 0; i < children.length; i++) {
@@ -28,17 +28,17 @@ RovingMultiselect.prototype.handleClick = function(e) {
   }
 };
 
-RovingMultiselect.prototype.handleFocusIn = function() {
-  const childId = this.focusedItem.getAttribute('id');
-  this.el.setAttribute('aria-activedescendant', childId);
+RovingMultiselect.prototype.handleFocusIn = function () {
+  const childId = this.focusedItem.getAttribute("id");
+  this.el.setAttribute("aria-activedescendant", childId);
 };
 
-RovingMultiselect.prototype.handleFocusOut = function() {
-  this.el.removeAttribute('aria-activedescendant');
+RovingMultiselect.prototype.handleFocusOut = function () {
+  this.el.removeAttribute("aria-activedescendant");
 };
 
-RovingMultiselect.prototype.handleKeyDown = function(e) {
-  switch(e.key) {
+RovingMultiselect.prototype.handleKeyDown = function (e) {
+  switch (e.key) {
     case keys.LEFT:
     case keys.UP: {
       e.preventDefault();
@@ -56,7 +56,7 @@ RovingMultiselect.prototype.handleKeyDown = function(e) {
     case keys.DOWN: {
       e.preventDefault();
 
-      if(this.selected === this.listItems.length - 1) {
+      if (this.selected === this.listItems.length - 1) {
         this.selected = 0;
       } else {
         this.selected = this.selected + 1;
@@ -65,7 +65,7 @@ RovingMultiselect.prototype.handleKeyDown = function(e) {
       break;
     }
 
-    case keys.ENTER: {
+    case keys.SPACE: {
       e.preventDefault();
       this.toggleChecked();
       this.toggleHelperText();
@@ -74,46 +74,49 @@ RovingMultiselect.prototype.handleKeyDown = function(e) {
   }
 };
 
-RovingMultiselect.prototype.toggleChecked = function() {
-  if (this.focusedItem.getAttribute('aria-checked') === 'true') {
-    this.focusedItem.setAttribute('aria-checked', 'false');
+RovingMultiselect.prototype.toggleChecked = function () {
+  if (this.focusedItem.getAttribute("aria-checked") === "true") {
+    this.focusedItem.setAttribute("aria-checked", "false");
   } else {
-    this.focusedItem.setAttribute('aria-checked', 'true');
+    this.focusedItem.setAttribute("aria-checked", "true");
   }
 };
 
-RovingMultiselect.prototype.toggleHelperText = function() {
-  const isSelected = this.focusedItem.getAttribute('aria-checked');
+RovingMultiselect.prototype.toggleHelperText = function () {
+  const isSelected = this.focusedItem.getAttribute("aria-checked");
   let screenReaderText = this.focusedItem.lastElementChild;
 
-  if (isSelected === 'true') {
-    screenReaderText.textContent = '  is checked'
+  if (isSelected === "true") {
+    screenReaderText.textContent = "  is checked";
   } else {
-    screenReaderText.textContent = '  is unchecked'
+    screenReaderText.textContent = "  is unchecked";
   }
 };
 
-RovingMultiselect.prototype.createUniqueId = function(listItems) {
-  listItems.forEach(item => {
-    item.setAttribute('id', uniqueId('multiselect-item'));
+RovingMultiselect.prototype.createUniqueId = function (listItems) {
+  listItems.forEach((item) => {
+    item.setAttribute("id", uniqueId("multiselect-item"));
   });
 };
 
-RovingMultiselect.prototype.changeFocus = function(idx) {
+RovingMultiselect.prototype.changeFocus = function (idx) {
   const parent = this.focusedItem.parentNode;
 
   // Set the old button to tabindex -1
   this.focusedItem.tabIndex = -1;
-  this.focusedItem.setAttribute('aria-selected', 'false');
-  this.focusedItem.classList.remove('roving-multiselect-list-item--selected');
+  this.focusedItem.setAttribute("aria-selected", "false");
+  this.focusedItem.classList.remove("roving-multiselect-list-item--selected");
 
   // Set the new button to tabindex 0 and focus it
   this.focusedItem = this.listItems[idx];
   this.focusedItem.tabIndex = 0;
   this.focusedItem.focus();
-  this.focusedItem.setAttribute('aria-selected', 'true');
-  this.focusedItem.classList.add('roving-multiselect-list-item--selected');
-  parent.setAttribute('aria-activedescendant', this.focusedItem.getAttribute('id'));
+  this.focusedItem.setAttribute("aria-selected", "true");
+  this.focusedItem.classList.add("roving-multiselect-list-item--selected");
+  parent.setAttribute(
+    "aria-activedescendant",
+    this.focusedItem.getAttribute("id")
+  );
 };
 
 export default RovingMultiselect;

--- a/roving-tab-index/js/modules/RovingTabindex.js
+++ b/roving-tab-index/js/modules/RovingTabindex.js
@@ -1,21 +1,20 @@
-import slice from '../helpers/slice.js';
-import uniqueId from '../helpers/uniqueId.js';
+import uniqueId from "../helpers/uniqueId.js";
 import { keys } from "../constants/constants.js";
 
 function RovingTabindex(id, targetClass) {
   this.el = document.querySelector(id);
-  this.listItems = slice(this.el.querySelectorAll(targetClass));
+  this.listItems = [...this.el.querySelectorAll(targetClass)];
   this.selected = 0;
   this.focusedItem = this.listItems[this.selected];
   this.createUniqueId(this.listItems);
-  
-  this.el.addEventListener('focusin', this.handleFocusIn.bind(this));
-  this.el.addEventListener('focusout', this.handleFocusOut.bind(this));
-  this.el.addEventListener('keydown', this.handleKeyDown.bind(this));
-  this.el.addEventListener('click', this.handleClick.bind(this));
-};
 
-RovingTabindex.prototype.handleClick = function(e) {
+  this.el.addEventListener("focusin", this.handleFocusIn.bind(this));
+  this.el.addEventListener("focusout", this.handleFocusOut.bind(this));
+  this.el.addEventListener("keydown", this.handleKeyDown.bind(this));
+  this.el.addEventListener("click", this.handleClick.bind(this));
+}
+
+RovingTabindex.prototype.handleClick = function (e) {
   const children = e.target.parentNode.children;
 
   for (let i = 0; i < children.length; i++) {
@@ -26,17 +25,17 @@ RovingTabindex.prototype.handleClick = function(e) {
   }
 };
 
-RovingTabindex.prototype.handleFocusIn = function() {
-  const childId = this.focusedItem.getAttribute('id');
-  this.el.setAttribute('aria-activedescendant', childId);
+RovingTabindex.prototype.handleFocusIn = function () {
+  const childId = this.focusedItem.getAttribute("id");
+  this.el.setAttribute("aria-activedescendant", childId);
 };
 
-RovingTabindex.prototype.handleFocusOut = function() {
-  this.el.removeAttribute('aria-activedescendant');
+RovingTabindex.prototype.handleFocusOut = function () {
+  this.el.removeAttribute("aria-activedescendant");
 };
 
-RovingTabindex.prototype.handleKeyDown = function(e) {
-  switch(e.key) {
+RovingTabindex.prototype.handleKeyDown = function (e) {
+  switch (e.key) {
     case keys.LEFT:
     case keys.UP: {
       e.preventDefault();
@@ -54,7 +53,7 @@ RovingTabindex.prototype.handleKeyDown = function(e) {
     case keys.DOWN: {
       e.preventDefault();
 
-      if(this.selected === this.listItems.length - 1) {
+      if (this.selected === this.listItems.length - 1) {
         this.selected = 0;
       } else {
         this.selected = this.selected + 1;
@@ -65,28 +64,31 @@ RovingTabindex.prototype.handleKeyDown = function(e) {
   }
 };
 
-RovingTabindex.prototype.changeFocus = function(idx) {
+RovingTabindex.prototype.changeFocus = function (idx) {
   const parent = this.focusedItem.parentNode;
 
   // Set the old button to tabindex -1
   this.focusedItem.tabIndex = -1;
-  this.focusedItem.setAttribute('aria-checked', 'false');
-  this.focusedItem.setAttribute('aria-selected', 'false');
-  this.focusedItem.classList.remove('roving-list-item--selected');
+  this.focusedItem.setAttribute("aria-checked", "false");
+  this.focusedItem.setAttribute("aria-selected", "false");
+  this.focusedItem.classList.remove("roving-list-item--selected");
 
   // Set the new button to tabindex 0 and focus it
   this.focusedItem = this.listItems[idx];
   this.focusedItem.tabIndex = 0;
   this.focusedItem.focus();
-  this.focusedItem.setAttribute('aria-checked', 'true');
-  this.focusedItem.setAttribute('aria-selected', 'true');
-  this.focusedItem.classList.add('roving-list-item--selected');
-  parent.setAttribute('aria-activedescendant', this.focusedItem.getAttribute('id'));
+  this.focusedItem.setAttribute("aria-checked", "true");
+  this.focusedItem.setAttribute("aria-selected", "true");
+  this.focusedItem.classList.add("roving-list-item--selected");
+  parent.setAttribute(
+    "aria-activedescendant",
+    this.focusedItem.getAttribute("id")
+  );
 };
 
-RovingTabindex.prototype.createUniqueId = function(listItems) {
-  listItems.forEach(item => {
-    item.setAttribute('id', uniqueId('select'));
+RovingTabindex.prototype.createUniqueId = function (listItems) {
+  listItems.forEach((item) => {
+    item.setAttribute("id", uniqueId("select"));
   });
 };
 


### PR DESCRIPTION
Revising the roving multiselect `keydown` listener to use `Space` than `Enter`. This change was prompted by the latest WAI-ARIA listbox pattern recommendation.

PR closes #28.